### PR TITLE
Proper URL decoding on file:/// references

### DIFF
--- a/src/RemoteRef/BasicFetcher.php
+++ b/src/RemoteRef/BasicFetcher.php
@@ -8,6 +8,6 @@ class BasicFetcher implements RemoteRefProvider
 {
     public function getSchemaData($url)
     {
-        return json_decode(file_get_contents($url));
+        return json_decode(file_get_contents(rawurldecode($url)));
     }
 }

--- a/tests/resources/remotes/#special~characters%directory/subSchemas.json
+++ b/tests/resources/remotes/#special~characters%directory/subSchemas.json
@@ -1,0 +1,19 @@
+{
+    "integer": {
+        "type": "integer"
+    }, 
+    "refToInteger": {
+        "$ref": "#/integer"
+    },
+    "indirectRefToInteger": {
+        "allOf": [
+            {},
+            {
+                "$ref": "#/refToInteger"
+            }
+        ]
+    },
+    "refToExternalInteger": {
+        "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    }
+}

--- a/tests/src/PHPUnit/Ref/FileResolverTest.php
+++ b/tests/src/PHPUnit/Ref/FileResolverTest.php
@@ -113,6 +113,22 @@ JSON
         $schema->in('abc');
     }
 
+    function testFileReferenceRealpathWithSpecialCharacters()
+    {
+        $pathToExternalSchema = realpath(__DIR__ . '/../../../resources/remotes/#special~characters%directory/subSchemas.json');
+        $pathToExternalSchema = str_replace('#special~characters%directory', rawurlencode('#special~characters%directory'), $pathToExternalSchema);
+        $schemaData = json_decode(<<<JSON
+{"\$ref": "file://$pathToExternalSchema#/integer"}
+JSON
+        );
+
+        $schema = Schema::import($schemaData);
+        $schema->in(123);
+
+        $this->setExpectedException(get_class(new InvalidValue()));
+        $schema->in('abc');
+    }
+
     function testFileReferenceNoProtocolScheme()
     {
         $pathToExternalSchema = __DIR__ . '/../../../resources/remotes/subSchemas.json';


### PR DESCRIPTION
`file:///` references are also URIs (as per [RFC 8089](https://tools.ietf.org/html/rfc8089)) so they should also be decoded properly.

Without this patch I can't have a local path reference including a hash `#` in it. Now local file references can be encoded and used properly, even with directories or files including hashes.