### PR TITLE
Improve regex delimiters, fixes #71

### DIFF
--- a/src/Constraint/Format.php
+++ b/src/Constraint/Format.php
@@ -108,15 +108,7 @@ class Format
             return 'Invalid regex: \A is not supported';
         }
 
-
-        $d = null;
-        foreach (array('/', '_', '~', '#', '!', '%', '`', '=') as $delimiter) {
-            if (strpos($data, $delimiter) === false) {
-                $d = $delimiter;
-                break;
-            }
-        }
-        return @preg_match($d . $data . $d, '') === false ? 'Invalid regex: ' . $data : null;
+        return @preg_match('{' . $data . '}', '') === false ? 'Invalid regex: ' . $data : null;
     }
 
     public static function jsonPointerError($data, $isRelative = false)

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -7,26 +7,11 @@ class Helper
 {
     /**
      * @param string $jsonPattern
-     * @return bool|string
-     * @throws InvalidValue
+     * @return string
      */
     public static function toPregPattern($jsonPattern)
     {
-        static $delimiters = array('/', '#', '+', '~', '%');
-
-        $pattern = false;
-        foreach ($delimiters as $delimiter) {
-            if (strpos($jsonPattern, $delimiter) === false) {
-                $pattern = $delimiter . $jsonPattern . $delimiter . 'u';
-                break;
-            }
-        }
-
-        if (false === $pattern) {
-            throw new InvalidValue('Failed to prepare preg pattern');
-        }
-
-        return $pattern;
+        return '{' . $jsonPattern . '}u';
     }
 
     /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1310,6 +1310,8 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
     }
 
     /**
+     * Resolves boolean schema into Schema instance
+     *
      * @param mixed $schema
      * @return mixed|Schema
      */

--- a/tests/src/PHPUnit/Misc/PreparePatternTest.php
+++ b/tests/src/PHPUnit/Misc/PreparePatternTest.php
@@ -3,13 +3,13 @@
 namespace Swaggest\JsonSchema\Tests\PHPUnit\Misc;
 
 use Swaggest\JsonSchema\Helper;
-use Swaggest\JsonSchema\InvalidValue;
 
 class PreparePatternTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFailedToPreparePattern()
+    public function testPreparePatternForEmail()
     {
-        $this->setExpectedException(get_class(new InvalidValue()), 'Failed to prepare preg pattern');
-        Helper::toPregPattern('/#+~%');
+        $pattern = Helper::toPregPattern('^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
+        $this->assertEquals(1, preg_match($pattern, 'name@host.com'));
+        $this->assertEquals(0, preg_match($pattern, "malformed-email"));
     }
 }


### PR DESCRIPTION
This PR enables support for regular expressions containing special chars conflicting with list of allowed delimiters. A more [compatible solution](http://codelegance.com/ideal-regex-delimiters-in-php/) is using `{` ... `}` as delimiters.