### PR TITLE
Check for null before accessing the array offset

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -664,7 +664,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                 $refProperty = null;
                 $dereference = true;
 
-                if (isset($array[self::PROP_REF])) {
+                if ($this->properties !== null && isset($array[self::PROP_REF])) {
                     $refProperty = $this->properties[self::PROP_REF];
 
                     if (isset($refProperty) && ($refProperty->format !== Format::URI_REFERENCE)) {


### PR DESCRIPTION
Hi.

We have a build that fails on PHP 7.4 due to a missing check for `null`.

You can see the build here: https://travis-ci.org/netgen-layouts/layouts-core/jobs/564002323