### PR TITLE
Restore proper $ref handling in mapped classes (broken in v0.12.6)

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -665,7 +665,14 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                 $dereference = true;
 
                 if ($this->properties !== null && isset($array[self::PROP_REF])) {
-                    $refProperty = $this->properties[self::PROP_REF];
+                    $refPropName = self::PROP_REF;
+                    if ($hasMapping) {
+                        if (isset($this->properties->__dataToProperty[$options->mapping][self::PROP_REF])) {
+                            $refPropName = $this->properties->__dataToProperty[$options->mapping][self::PROP_REF];
+                        }
+                    }
+
+                    $refProperty = $this->properties[$refPropName];
 
                     if (isset($refProperty) && ($refProperty->format !== Format::URI_REFERENCE)) {
                         $dereference = false;

--- a/src/Structure/ObjectItemTrait.php
+++ b/src/Structure/ObjectItemTrait.php
@@ -16,6 +16,7 @@ trait ObjectItemTrait
     /** @var ObjectItemContract[] */
     protected $__nestedObjects;
     protected $__documentPath;
+    /** @var null|string[] */
     protected $__fromRef;
 
     public function getNestedObject($className)

--- a/src/Structure/ObjectItemTrait.php
+++ b/src/Structure/ObjectItemTrait.php
@@ -113,7 +113,7 @@ trait ObjectItemTrait
     }
 
     /**
-     * @return string
+     * @return string|null
      * @deprecated use ObjectItemContract::getFromRefs
      * @see ObjectItemContract::getFromRefs
      * @todo remove


### PR DESCRIPTION
This PR fixes `$ref` property check that was broken few versions ago. The issue causes failure of https://github.com/swaggest/php-code-builder/blob/v0.2.7/tests/src/PHPUnit/Swagger/ImportTest.php#L12.