### PR TITLE
Do not fail validation of dereferenced value if original data is valid

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -25,6 +25,7 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 use Swaggest\JsonSchema\Structure\Egg;
 use Swaggest\JsonSchema\Structure\ObjectItem;
 use Swaggest\JsonSchema\Structure\ObjectItemContract;
+use Swaggest\JsonSchema\Structure\WithResolvedValue;
 
 /**
  * Class Schema
@@ -702,6 +703,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                     });
 
                     $ref = $refResolver->resolveReference($refString);
+                    $unresolvedData = $data;
                     $data = self::unboolSchemaData($ref->getData());
                     if (!$options->validateOnly) {
                         if ($ref->isImported()) {
@@ -710,6 +712,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                         }
                         $ref->setImported($result);
                         try {
+                            // Best effort dereference delivery.
                             $refResult = $this->process($data, $options, $path . '->$ref:' . $refString, $result);
                             if ($refResult instanceof ObjectItemContract) {
                                 if ($refResult->getFromRefs()) {
@@ -718,11 +721,28 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                                 $refResult->setFromRef($refString);
                             }
                             $ref->setImported($refResult);
+                            return $refResult;
                         } catch (InvalidValue $exception) {
                             $ref->unsetImported();
-                            throw $exception;
+                            $skipValidation = $options->skipValidation;
+                            $options->skipValidation = true;
+                            $refResult = $this->process($data, $options, $path . '->$ref:' . $refString);
+                            if ($refResult instanceof ObjectItemContract) {
+                                if ($refResult->getFromRefs()) {
+                                    $refResult = clone $refResult; // @todo check performance, consider option
+                                }
+                                $refResult->setFromRef($refString);
+                            }
+                            $ref->setImported($refResult);
+                            $options->skipValidation = $skipValidation;
+
+                            if ($result instanceof WithResolvedValue) {
+                                $result->setResolvedValue($refResult);
+                            }
+
+                            // Proceeding with unresolved data.
+                            $data = $unresolvedData;
                         }
-                        return $refResult;
                     } else {
                         $this->process($data, $options, $path . '->$ref:' . $refString);
                     }

--- a/src/Structure/ObjectItem.php
+++ b/src/Structure/ObjectItem.php
@@ -11,7 +11,7 @@ namespace Swaggest\JsonSchema\Structure;
  * @method string|null getFromRef();
  * @method string[]|null getFromRefs();
  */
-class ObjectItem implements ObjectItemContract
+class ObjectItem implements ObjectItemContract, WithResolvedValue
 {
     use ObjectItemTrait;
 }

--- a/src/Structure/ObjectItemTrait.php
+++ b/src/Structure/ObjectItemTrait.php
@@ -19,6 +19,26 @@ trait ObjectItemTrait
     /** @var null|string[] */
     protected $__fromRef;
 
+    protected $__hasResolvedValue = false;
+    protected $__resolvedValue;
+
+    public function setResolvedValue($value)
+    {
+        $this->__hasResolvedValue = true;
+        $this->__resolvedValue = $value;
+        return $this;
+    }
+
+    public function getResolvedValue()
+    {
+        return $this->__resolvedValue;
+    }
+
+    public function hasResolvedValue()
+    {
+        return $this->__hasResolvedValue;
+    }
+
     public function getNestedObject($className)
     {
         if (isset($this->__nestedObjects[$className])) {

--- a/src/Structure/WithResolvedValue.php
+++ b/src/Structure/WithResolvedValue.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Swaggest\JsonSchema\Structure;
+
+
+interface WithResolvedValue
+{
+    public function setResolvedValue($value);
+
+    public function getResolvedValue();
+
+    public function hasResolvedValue();
+
+}

--- a/tests/resources/suite/oneOfRef.json
+++ b/tests/resources/suite/oneOfRef.json
@@ -1,0 +1,51 @@
+[
+  {
+    "description": "oneOfRef",
+    "schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "dataKey"
+          ]
+        }
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid against data",
+        "data": {
+          "dataKey": true
+        },
+        "valid": true
+      },
+      {
+        "description": "valid against reference",
+        "data": {
+          "$ref": "#/container",
+          "container": {
+            "dataKey": true
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid against not an object",
+        "data": 123,
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR fixes validation error in case of one of reference and value, the issue is that validation was running against both value and reference making sometimes both items of `oneOf` pass.