### PR TITLE
Export properties with null as a value

### DIFF
--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -92,15 +92,33 @@ trait ClassStructureTrait
 
     protected $__validateOnSet = true; // todo skip validation during import
 
+    /**
+     * @return \stdClass
+     */
     public function jsonSerialize()
     {
         $result = new \stdClass();
         $schema = static::schema();
+        $classname = $schema->getObjectItemClass();
+        $classReference = (class_exists($classname)) ? new $classname() : new \stdClass();
         $properties = $schema->getProperties();
         if (null !== $properties) {
             foreach ($properties->getDataKeyMap() as $propertyName => $dataName) {
                 $value = $this->$propertyName;
-                if ((null !== $value) || array_key_exists($propertyName, $this->__arrayOfData)) {
+                $types = ($schema->getProperty($propertyName) instanceof Schema)
+                    ? $schema->getProperty($propertyName)->type
+                    : null;
+                if (
+                    (
+                        null !== $value
+                        ||
+                        ($value === null
+                            && is_array($types)
+                            && in_array('null', $types)
+                        )
+                    )
+                    || array_key_exists($propertyName, $this->__arrayOfData)
+                ) {
                     $result->$dataName = $value;
                 }
             }


### PR DESCRIPTION
Hi,

I noticed that properties having `null` as a value are not exported. These properties are just missing in an exported JSON file. But I wanted/needed all these properties in my current project - so I created a "feature" for it.

You can trigger this behavior with an option, which is passed through to the jsonSerialize method. It's not the nicest way to control it, but I didn't find another way.  Feedback very welcome.

Output without option:
`{
    "id": 123,
    "foo": "bar"
}`

Output with option:
`{
    "id": 123,
    "foo": "bar",
    "null_property": null
}`