### PR TITLE
Add continuous benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 /xhprof_report.*
 benchmark-result.json
 /coverage.xml
+/phpbench-candidate.xml
+/phpbench-master.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
 script:
   - php -derror_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit -v --configuration phpunit.xml --coverage-text --coverage-clover=coverage.xml
   - if [[ $(phpenv version-name) =~ 7.3 ]] ; then make test-coverage; else make test; fi
-  - if [[ $(phpenv version-name) =~ 7.2 ]] ; then make lint; fi
+  - if [[ $(phpenv version-name) =~ 7.2 ]] ; then make lint;make bench;make bench-master;make bench-compare; fi
 
 after_script:
   - if [[ $(phpenv version-name) =~ 7.3 ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/benchmarks/AjvSchemasBench.php
+++ b/benchmarks/AjvSchemasBench.php
@@ -1,0 +1,139 @@
+<?php
+
+
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\InvalidValue;
+use Swaggest\JsonSchema\RemoteRef\Preloaded;
+use Swaggest\JsonSchema\Schema;
+
+class AjvSchemasBench
+{
+    private static $cases;
+
+    public function provide()
+    {
+        foreach (self::$cases as $name => $tmp) {
+            yield $name => ['name' => $name];
+        }
+    }
+
+    /**
+     * @ParamProviders({"provide"})
+     */
+    public function benchSpec($params)
+    {
+        $case = self::$cases[$params['name']];
+
+        $actualValid = true;
+        try {
+            $options = $this->makeOptions(Schema::VERSION_DRAFT_07);
+            $options->schemasCache = self::$schemas;
+
+            $schema = Schema::import($case['schema'], $options);
+
+            $options->validateOnly = true;
+            $schema->in($case['data'], $options);
+        } catch (InvalidValue $exception) {
+            $actualValid = false;
+        }
+
+        if ($actualValid !== $case['isValid']) {
+            throw new Exception('Assertion failed');
+        }
+    }
+
+    /** @var \SplObjectStorage */
+    private static $schemas;
+
+    protected function makeOptions($version)
+    {
+        $refProvider = static::getProvider();
+
+        $options = new Context();
+        $options->setRemoteRefProvider($refProvider);
+        $options->version = $version;
+        $options->strictBase64Validation = true;
+
+        return $options;
+    }
+
+    public static function getProvider()
+    {
+        static $refProvider = null;
+
+        if (null === $refProvider) {
+            $refProvider = new Preloaded();
+            $refProvider
+                ->setSchemaData(
+                    'http://localhost:1234/integer.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/integer.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/subSchemas.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/subSchemas.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/name.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/name.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/folder/folderInteger.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/folder/folderInteger.json')));
+        }
+
+        return $refProvider;
+    }
+
+    private static function provider($path)
+    {
+        $testCases = array();
+
+        if ($handle = opendir($path)) {
+            while (false !== ($entry = readdir($handle))) {
+                if ($entry != "." && $entry != "..") {
+                    if ('.json' !== substr($entry, -5)) {
+                        continue;
+                    }
+                    $tests = json_decode(file_get_contents($path . '/' . $entry));
+
+                    foreach ($tests as $test) {
+                        foreach ($test->tests as $c => $case) {
+                            $name = $entry . ' ' . $test->description . ': ' . $case->description . ' [' . $c . ']';
+                            if (!isset($test->schema)) {
+                                if (isset($test->schemas)) {
+                                    foreach ($test->schemas as $i => $schema) {
+                                        $testCases[$name . '_' . $i] = array(
+                                            'schema' => $schema,
+                                            'data' => $case->data,
+                                            'isValid' => $case->valid,
+                                            'name' => $name,
+                                        );
+                                    }
+                                }
+                                continue;
+                            }
+                            $testCases[$name] = array(
+                                'schema' => $test->schema,
+                                'data' => $case->data,
+                                'isValid' => $case->valid,
+                                'name' => $name,
+                            );
+                        }
+                    }
+                }
+            }
+            closedir($handle);
+        }
+
+        return $testCases;
+    }
+
+    public static function init()
+    {
+        self::$cases = self::provider(__DIR__ . '/../spec/ajv/spec/tests/schemas');
+        self::$schemas = new \SplObjectStorage();
+    }
+}
+
+AjvSchemasBench::init();

--- a/benchmarks/Draft7Bench.php
+++ b/benchmarks/Draft7Bench.php
@@ -1,0 +1,139 @@
+<?php
+
+
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\InvalidValue;
+use Swaggest\JsonSchema\RemoteRef\Preloaded;
+use Swaggest\JsonSchema\Schema;
+
+class Draft7Bench
+{
+    private static $cases;
+
+    public function provide()
+    {
+        foreach (self::$cases as $name => $tmp) {
+            yield $name => ['name' => $name];
+        }
+    }
+
+    /**
+     * @ParamProviders({"provide"})
+     */
+    public function benchSpec($params)
+    {
+        $case = self::$cases[$params['name']];
+
+        $actualValid = true;
+        try {
+            $options = $this->makeOptions(Schema::VERSION_DRAFT_07);
+            $options->schemasCache = self::$schemas;
+
+            $schema = Schema::import($case['schema'], $options);
+
+            $options->validateOnly = true;
+            $schema->in($case['data'], $options);
+        } catch (InvalidValue $exception) {
+            $actualValid = false;
+        }
+
+        if ($actualValid !== $case['isValid']) {
+            throw new Exception('Assertion failed');
+        }
+    }
+
+    /** @var \SplObjectStorage */
+    private static $schemas;
+
+    protected function makeOptions($version)
+    {
+        $refProvider = static::getProvider();
+
+        $options = new Context();
+        $options->setRemoteRefProvider($refProvider);
+        $options->version = $version;
+        $options->strictBase64Validation = true;
+
+        return $options;
+    }
+
+    public static function getProvider()
+    {
+        static $refProvider = null;
+
+        if (null === $refProvider) {
+            $refProvider = new Preloaded();
+            $refProvider
+                ->setSchemaData(
+                    'http://localhost:1234/integer.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/integer.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/subSchemas.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/subSchemas.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/name.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/name.json')))
+                ->setSchemaData(
+                    'http://localhost:1234/folder/folderInteger.json',
+                    json_decode(file_get_contents(__DIR__
+                        . '/../spec/JSON-Schema-Test-Suite/remotes/folder/folderInteger.json')));
+        }
+
+        return $refProvider;
+    }
+
+    private static function provider($path)
+    {
+        $testCases = array();
+
+        if ($handle = opendir($path)) {
+            while (false !== ($entry = readdir($handle))) {
+                if ($entry != "." && $entry != "..") {
+                    if ('.json' !== substr($entry, -5)) {
+                        continue;
+                    }
+                    $tests = json_decode(file_get_contents($path . '/' . $entry));
+
+                    foreach ($tests as $test) {
+                        foreach ($test->tests as $c => $case) {
+                            $name = $entry . ' ' . $test->description . ': ' . $case->description . ' [' . $c . ']';
+                            if (!isset($test->schema)) {
+                                if (isset($test->schemas)) {
+                                    foreach ($test->schemas as $i => $schema) {
+                                        $testCases[$name . '_' . $i] = array(
+                                            'schema' => $schema,
+                                            'data' => $case->data,
+                                            'isValid' => $case->valid,
+                                            'name' => $name,
+                                        );
+                                    }
+                                }
+                                continue;
+                            }
+                            $testCases[$name] = array(
+                                'schema' => $test->schema,
+                                'data' => $case->data,
+                                'isValid' => $case->valid,
+                                'name' => $name,
+                            );
+                        }
+                    }
+                }
+            }
+            closedir($handle);
+        }
+
+        return $testCases;
+    }
+
+    public static function init()
+    {
+        self::$cases = self::provider(__DIR__ . '/../spec/JSON-Schema-Test-Suite/tests/draft7');
+        self::$schemas = new \SplObjectStorage();
+    }
+}
+
+Draft7Bench::init();


### PR DESCRIPTION
This PR adds [phpbench](https://github.com/phpbench/phpbench) benchmarks to the code base (`make bench`) and enables benchmarks in CI with results being compared to `master` performance.

Example: https://travis-ci.org/swaggest/php-json-schema/jobs/582667726#L1174