### PR TITLE
Keep proper object class

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -593,10 +593,13 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
 
                 if ($this->useObjectAsArray) {
                     $result = array();
-                } else/*if (!$result instanceof ObjectItemContract || null !== $this->objectItemClass)*/ {
+                } else {
                     //* todo check performance impact
                     if (null === $this->objectItemClass) {
-                        $result = new ObjectItem();
+                        if (!$result instanceof ObjectItemContract) {
+                            $result = new ObjectItem();
+                            $result->setDocumentPath($path);
+                        }
                     } else {
                         $className = $this->objectItemClass;
                         if ($options->objectItemClassMapping !== null) {
@@ -604,26 +607,23 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
                                 $className = $options->objectItemClassMapping[$className];
                             }
                         }
-                        $result = new $className;
-                    }
-                    //*/
-
-
-                    if ($result instanceof ClassStructure) {
-                        if ($result->__validateOnSet) {
-                            $result->__validateOnSet = false;
-                            /** @noinspection PhpUnusedLocalVariableInspection */
-                            /* todo check performance impact
-                            $validateOnSetHandler = new ScopeExit(function () use ($result) {
-                                $result->__validateOnSet = true;
-                            });
+                        if (null !== $result && get_class($result) !== $className) {
+                            $result = new $className;
+                            //* todo check performance impact
+                            if ($result instanceof ClassStructure) {
+                                $result->setDocumentPath($path);
+                                if ($result->__validateOnSet) {
+                                    $result->__validateOnSet = false;
+                                    /** @noinspection PhpUnusedLocalVariableInspection */
+                                    /* todo check performance impact
+                                    $validateOnSetHandler = new ScopeExit(function () use ($result) {
+                                        $result->__validateOnSet = true;
+                                    });
+                                    //*/
+                                }
+                            }
                             //*/
                         }
-                    }
-
-                    //* todo check performance impact
-                    if ($result instanceof ObjectItemContract) {
-                        $result->setDocumentPath($path);
                     }
                     //*/
                 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -593,7 +593,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
 
                 if ($this->useObjectAsArray) {
                     $result = array();
-                } elseif (!$result instanceof ObjectItemContract) {
+                } else/*if (!$result instanceof ObjectItemContract || null !== $this->objectItemClass)*/ {
                     //* todo check performance impact
                     if (null === $this->objectItemClass) {
                         $result = new ObjectItem();

--- a/tests/src/Helper/ClassWithAllOf.php
+++ b/tests/src/Helper/ClassWithAllOf.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Swaggest\JsonSchema\Tests\Helper;
+
+
+use Swaggest\JsonSchema\Constraint\Properties;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Structure\ClassStructure;
+
+class ClassWithAllOf extends ClassStructure
+{
+    public $myProperty;
+
+    /**
+     * @param Properties|static $properties
+     * @param Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Schema $ownerSchema)
+    {
+        $properties->myProperty = Schema::string();
+
+        $not = new Schema();
+        $not->not = Schema::integer();
+        $ownerSchema->allOf[0] = $not;
+    }
+
+
+}

--- a/tests/src/PHPUnit/ClassStructure/ClassStructureTest.php
+++ b/tests/src/PHPUnit/ClassStructure/ClassStructureTest.php
@@ -4,6 +4,7 @@ namespace Swaggest\JsonSchema\Tests\PHPUnit\ClassStructure;
 
 
 use Swaggest\JsonSchema\Exception\TypeException;
+use Swaggest\JsonSchema\Tests\Helper\ClassWithAllOf;
 use Swaggest\JsonSchema\Tests\Helper\LevelThreeClass;
 use Swaggest\JsonSchema\Tests\Helper\SampleStructure;
 use Swaggest\JsonSchema\Tests\Helper\StructureWithItems;
@@ -86,6 +87,13 @@ class ClassStructureTest extends \PHPUnit_Framework_TestCase
                 'propTwo' => 22,
             )
         ));
+    }
+
+    public function testAllOfClassInstance()
+    {
+        $value = ClassWithAllOf::import((object)array('myProperty'=>'abc'));
+        $this->assertSame('abc', $value->myProperty);
+        $this->assertTrue($value instanceof ClassWithAllOf);
     }
 
 


### PR DESCRIPTION
This PR fixes import of `ClassStructure` when `*Of` on owner schema is defined, currently in such situation an instance of `ObjectItem` is created instead of an instance of `ClassStructure` implementation.