### PR TITLE
fix - remove double semicolon

### DIFF
--- a/src/MagicMapTrait.php
+++ b/src/MagicMapTrait.php
@@ -23,7 +23,7 @@ trait MagicMapTrait
             return $this->__arrayOfData[$name];
         } else {
             $tmp = null;
-            return $tmp;;
+            return $tmp;
         }
     }
 


### PR DESCRIPTION
There is double semicolon at the end of a line. It's aesthetic, lets' remove it!