### PR TITLE
Fix tolerateStrings to validate types properly

### DIFF
--- a/src/Constraint/Type.php
+++ b/src/Constraint/Type.php
@@ -40,7 +40,7 @@ class Type implements Constraint
                     break;
                 case self::BOOLEAN:
                     $newData = filter_var($data, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-                    $ok = is_bool($data);
+                    $ok = is_bool($newData);
                     break;
                 case self::NULL:
                     break;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -204,7 +204,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
      * @throws InvalidValue
      * @throws \Exception
      */
-    private function processType($data, Context $options, $path = '#')
+    private function processType(&$data, Context $options, $path = '#')
     {
         if ($options->tolerateStrings && is_string($data)) {
             $valid = Type::readString($this->type, $data);

--- a/tests/src/PHPUnit/TolerateStringsTest.php
+++ b/tests/src/PHPUnit/TolerateStringsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Swaggest\JsonSchema\Tests\PHPUnit;
+
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\InvalidValue;
+use Swaggest\JsonSchema\Schema;
+
+class TolerateStringsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWithTolerateStrings()
+    {
+        $json_schema = json_decode(
+            json_encode(
+                [
+                    'items' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                        ['type' => 'number'],
+                        ['type' => 'boolean'],
+                        [
+                            'type' => 'integer',
+                            'enum' => [1, 2, 3]
+                        ]
+                    ]
+                ]
+            )
+        );
+
+        $data = [
+            'text',
+            '10',
+            '123.45',
+            'true',
+            '2'
+        ];
+
+        $options = new Context();
+        $options->tolerateStrings = true;
+
+        $schema = Schema::import($json_schema);
+
+        $this->assertSame($data, $schema->in($data, $options));
+    }
+
+    public function testWithTolerateStringsBadNumber()
+    {
+        $json_schema = json_decode(
+            json_encode(
+                [
+                    'items' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                        ['type' => 'number'],
+                        ['type' => 'boolean']
+                    ]
+                ]
+            )
+        );
+
+        $data = [
+            'text',
+            '10',
+            'bad',
+            'true'
+        ];
+
+        $options = new Context();
+        $options->tolerateStrings = true;
+
+        $schema = Schema::import($json_schema);
+
+        $this->setExpectedException(get_class(new InvalidValue()), 'Number expected, "bad" received at #->items:2');
+        $schema->in($data, $options);
+    }
+
+    public function testWithTolerateStringsBadInteger()
+    {
+        $json_schema = json_decode(
+            json_encode(
+                [
+                    'items' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                        ['type' => 'number'],
+                        ['type' => 'boolean']
+                    ]
+                ]
+            )
+        );
+
+        $data = [
+            'text',
+            'bad',
+            '123.45',
+            'true'
+        ];
+
+        $options = new Context();
+        $options->tolerateStrings = true;
+
+        $schema = Schema::import($json_schema);
+
+        $this->setExpectedException(get_class(new InvalidValue()), 'Integer expected, "bad" received at #->items:1');
+        $schema->in($data, $options);
+    }
+
+    public function testWithTolerateStringsBadBoolean()
+    {
+        $json_schema = json_decode(
+            json_encode(
+                [
+                    'items' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                        ['type' => 'number'],
+                        ['type' => 'boolean']
+                    ]
+                ]
+            )
+        );
+
+        $data = [
+            'text',
+            '10',
+            '123.45',
+            'bad'
+        ];
+
+        $options = new Context();
+        $options->tolerateStrings = true;
+
+        $schema = Schema::import($json_schema);
+
+        $this->setExpectedException(get_class(new InvalidValue()), 'Boolean expected, "bad" received at #->items:3');
+        $schema->in($data, $options);
+    }
+
+    public function testWithTolerateStringsBadEnum()
+    {
+        $json_schema = json_decode(
+            json_encode(
+                [
+                    'items' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                        ['type' => 'number'],
+                        ['type' => 'boolean'],
+                        [
+                            'type' => 'integer',
+                            'enum' => [1, 2, 3]
+                        ]
+                    ]
+                ]
+            )
+        );
+
+        $data = [
+            'text',
+            '10',
+            '123.45',
+            'true',
+            '5'
+        ];
+
+        $options = new Context();
+        $options->tolerateStrings = true;
+
+        $schema = Schema::import($json_schema);
+
+        $this->setExpectedException(get_class(new InvalidValue()), 'Enum failed, enum: [1,2,3], data: 5 at #->items:4');
+        $schema->in($data, $options);
+    }
+}


### PR DESCRIPTION
At the moment, if you try to use a custom Context with 'tolerateStrings' set to 'true' it will not validate types properly.

Fixed tolerateStrings to validate types properly. Also added tests to validate usage of tolerateStrings.