### PR TITLE
Return properly cast data when using tolerateStrings

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1116,10 +1116,6 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
             $data = $options->dataPreProcessor->process($data, $this, $import);
         }
 
-        if ($result === null) {
-            $result = $data;
-        }
-
         if ($options->skipValidation) {
             goto skipValidation;
         }
@@ -1153,6 +1149,10 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
         }
 
         skipValidation:
+
+        if ($result === null) {
+            $result = $data;
+        }
 
         if ($this->oneOf !== null) {
             $result = $this->processOneOf($data, $options, $path);

--- a/tests/src/PHPUnit/TolerateStringsTest.php
+++ b/tests/src/PHPUnit/TolerateStringsTest.php
@@ -35,12 +35,20 @@ class TolerateStringsTest extends \PHPUnit_Framework_TestCase
             '2'
         ];
 
+        $expected_data = [
+            'text',
+            10,
+            123.45,
+            true,
+            2
+        ];
+
         $options = new Context();
         $options->tolerateStrings = true;
 
         $schema = Schema::import($json_schema);
 
-        $this->assertSame($data, $schema->in($data, $options));
+        $this->assertSame($expected_data, $schema->in($data, $options));
     }
 
     public function testWithTolerateStringsBadNumber()


### PR DESCRIPTION
At the moment, when using `tolerateStrings` the returned data from `$schema->in(...);` will still return all data as strings even if data is properly validated/cast internally. Unfortunately that internal data is never returned.

This simple fix simply moves the `$return` variable assignment to after the `skipValidation` part instead of before. This makes it so the data that is internally fixed is now properly assigned to the `$return` variable and thus, returned. Nothing else is impacted by this change.

The TolerateStringsTest was also adjusted to validate that proper casting is returned.