### PR TITLE
Adding serialization of additional and pattern properties

### DIFF
--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -13,6 +13,12 @@ trait ClassStructureTrait
     use ObjectItemTrait;
 
     /**
+     * Serialize additional and pattern properties
+     * @var boolean
+     */
+    protected $extendedPropertySerialization = false;
+
+    /**
      * @return Wrapper
      */
     public static function schema()
@@ -129,6 +135,16 @@ trait ClassStructureTrait
             }
         }
 
+        if ($this->extendedPropertySerialization) {
+            foreach ($this->getAdditionalPropertyNames() as $name) {
+                $result->$name = $this->{$name};
+            }
+
+            foreach ($this->getAllPatternPropertyNames() as $name) {
+                $result->$name = $this->{$name};
+            }
+        }
+
         return $result;
     }
 
@@ -167,5 +183,16 @@ trait ClassStructureTrait
     public function validate()
     {
         static::schema()->out($this);
+    }
+
+    /**
+     * Setter for $extendedPropertySerialization
+     * @param boolean $extend
+     * @return self
+     */
+    public function setExtendedPropertySerialization($extend = true)
+    {
+        $this->extendedPropertySerialization = $extend;
+        return $this;
     }
 }

--- a/src/Structure/ObjectItemTrait.php
+++ b/src/Structure/ObjectItemTrait.php
@@ -103,6 +103,22 @@ trait ObjectItemTrait
         return null;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getAllPatternPropertyNames()
+    {
+        $result = array();
+        if (isset($this->__patternPropertyNames)) {
+            foreach ($this->__patternPropertyNames as $patternProperties) {
+                if (is_array($patternProperties)) {
+                    $result = array_merge($result, array_keys($patternProperties));
+                }
+            }
+        }
+        return $result;
+    }
+
     public function jsonSerialize()
     {
         if ($this->__nestedObjects) {

--- a/tests/src/Helper/SampleProperties.php
+++ b/tests/src/Helper/SampleProperties.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Swaggest\JsonSchema\Tests\Helper;
+
+use Swaggest\JsonSchema\Helper;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Exception\StringException;
+use Swaggest\JsonSchema\Structure\ClassStructure;
+
+
+/**
+ * @property string $propOne
+ * @property int $propTwo
+ * @property $recursion
+ */
+class SampleProperties extends ClassStructure
+{
+    const X_PROPERTY_PATTERN = '^x-';
+
+    /**
+     * @param \Swaggest\JsonSchema\Constraint\Properties|static $properties
+     * @param Schema $schema
+     */
+    public static function setUpProperties($properties, Schema $schema)
+    {
+        $schema->type = Schema::OBJECT;
+        $schema->additionalProperties = Schema::object();
+        $schema->setPatternProperty('^x-', Schema::string());
+    }
+
+    /**
+     * @return array
+     * @codeCoverageIgnoreStart
+     */
+    public function getAdditionalPropertyValues()
+    {
+        $result = array();
+        if (!$names = $this->getAdditionalPropertyNames()) {
+            return $result;
+        }
+        foreach ($names as $name) {
+            $result[$name] = $this->$name;
+        }
+        return $result;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return self
+     * @codeCoverageIgnoreStart
+     */
+    public function setAdditionalPropertyValue($name, $value)
+    {
+        $this->addAdditionalPropertyName($name);
+        $this->{$name} = $value;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @return string[]
+     * @codeCoverageIgnoreStart
+     */
+    public function getXValues()
+    {
+        $result = array();
+        if (!$names = $this->getPatternPropertyNames(self::X_PROPERTY_PATTERN)) {
+            return $result;
+        }
+        foreach ($names as $name) {
+            $result[$name] = $this->$name;
+        }
+        return $result;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param string $name
+     * @param string $value
+     * @return self
+     * @throws InvalidValue
+     * @codeCoverageIgnoreStart
+     */
+    public function setXValue($name, $value)
+    {
+        if (!preg_match(Helper::toPregPattern(self::X_PROPERTY_PATTERN), $name)) {
+            throw new StringException('Pattern mismatch', StringException::PATTERN_MISMATCH);
+        }
+        $this->addPatternPropertyName(self::X_PROPERTY_PATTERN, $name);
+        $this->{$name} = $value;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @return string
+     * @codeCoverageIgnoreStart
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param string $lastName
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setLastName($lastName)
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+}


### PR DESCRIPTION
So far, if you added additional or pattern property values they would not be serialized:
```php
$properties = new Properties();
$properties->setAdditionalPropertyValue('propOne', 'foo');
$properties->setXValue('x-foo', 'bar');
Properties::export($properties);
// result: {}
```
Now, if you activate this feature, they also would be serialized:
```php
$properties = new Properties();
$properties->setExtendedPropertySerialization(true);
$properties->setAdditionalPropertyValue('propOne', 'foo');
$properties->setXValue('x-foo', 'bar');
Properties::export($properties);
// result: {"propOne": "foo", "x-foo": "bar"}
```