### PR TITLE
fix Trying to access array offset on value of type null (7.4)

### DIFF
--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -105,7 +105,7 @@ class Wrapper implements SchemaContract, MetaHolder, SchemaExporter, \JsonSerial
      */
     public function getProperty($name)
     {
-        return $this->schema->properties[$name];
+        return isset($this->schema->properties[$name]) ? $this->schema->properties[$name] : null;
     }
 
     /**


### PR DESCRIPTION
Without this fix


```
1) Swaggest\JsonSchema\Tests\PHPUnit\ClassStructure\ClassStructureTest::testAdditionalProperties
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-swaggest-json-schema-0.12.27-1.fc31.remi.x86_64/usr/share/php/Swaggest/JsonSchema/Wrapper.php:108
/dev/shm/BUILDROOT/php-swaggest-json-schema-0.12.27-1.fc31.remi.x86_64/usr/share/php/Swaggest/JsonSchema/Structure/ClassStructureTrait.php:161
/dev/shm/BUILD/php-json-schema-9ec863a05a40e9b4547bc0c43dc6992cf17307a3/tests/src/PHPUnit/ClassStructure/ClassStructureTest.php:102

2) Swaggest\JsonSchema\Tests\PHPUnit\ClassStructure\ClassStructureTest::testPatternProperties
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-swaggest-json-schema-0.12.27-1.fc31.remi.x86_64/usr/share/php/Swaggest/JsonSchema/Wrapper.php:108
/dev/shm/BUILDROOT/php-swaggest-json-schema-0.12.27-1.fc31.remi.x86_64/usr/share/php/Swaggest/JsonSchema/Structure/ClassStructureTrait.php:161
/dev/shm/BUILD/php-json-schema-9ec863a05a40e9b4547bc0c43dc6992cf17307a3/tests/src/Helper/SampleProperties.php:43
/dev/shm/BUILD/php-json-schema-9ec863a05a40e9b4547bc0c43dc6992cf17307a3/tests/src/PHPUnit/ClassStructure/ClassStructureTest.php:122


```