### PR TITLE
Allow properties mapping in reflected names

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,18 @@ class Order implements ClassStructureContract
         $properties->dateTime->format = Format::DATE_TIME;
         $properties->price = Schema::number();
 
-        $ownerSchema->required[] = self::names()->id;
+        $ownerSchema->setFromRef('#/definitions/order');
 
         // Define default mapping if any
         $ownerSchema->addPropertyMapping('date_time', Order::names()->dateTime);
+
+        // Use mapped name references after the default mapping was configured.
+        $names = self::names($ownerSchema->properties);
+        $ownerSchema->required = array(
+            $names->id,
+            $names->dateTime,
+            $names->price
+        );
 
         // Define additional mapping
         $ownerSchema->addPropertyMapping('DaTe_TiMe', Order::names()->dateTime, self::FANCY_MAPPING);

--- a/src/NameMirror.php
+++ b/src/NameMirror.php
@@ -4,8 +4,23 @@ namespace Swaggest\JsonSchema;
 
 class NameMirror
 {
+    /**
+     * NameMirror constructor.
+     * @param null|string[] $mapping a map of propertyName to dataName
+     */
+    public function __construct($mapping = null)
+    {
+        $this->mapping = $mapping;
+    }
+
+    private $mapping;
+
     public function __get($name)
     {
+        if ($this->mapping !== null && isset($this->mapping[$name])) {
+            return $this->mapping[$name];
+        }
+
         return $name;
     }
 

--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -146,8 +146,12 @@ trait ClassStructureTrait
     /**
      * @return static|NameMirror
      */
-    public static function names()
+    public static function names(Properties $properties = null, $mapping = Schema::DEFAULT_MAPPING)
     {
+        if ($properties !== null) {
+            return new NameMirror($properties->getDataKeyMap($mapping));
+        }
+
         static $nameflector = null;
         if (null === $nameflector) {
             $nameflector = new NameMirror();

--- a/tests/src/Helper/Order.php
+++ b/tests/src/Helper/Order.php
@@ -37,15 +37,18 @@ class Order implements ClassStructureContract
         $properties->dateTime->format = Format::DATE_TIME;
         $properties->price = Schema::number();
 
-        $ownerSchema->required = array(
-            self::names()->id,
-            'date_time',
-            self::names()->price
-        );
         $ownerSchema->setFromRef('#/definitions/order');
 
         // Define default mapping if any
         $ownerSchema->addPropertyMapping('date_time', Order::names()->dateTime);
+
+        // Use mapped name references after the default mapping was configured.
+        $names = self::names($ownerSchema->properties);
+        $ownerSchema->required = array(
+            $names->id,
+            $names->dateTime,
+            $names->price
+        );
 
         // Define additional mapping
         $ownerSchema->addPropertyMapping('DaTe_TiMe', Order::names()->dateTime, self::FANCY_MAPPING);


### PR DESCRIPTION
Resolves #124.

This PR upgrades names reflector with properties mappings, so that it is possible to use mapped names in further schema configuration.

Example:
```php
        // Define default mapping if any.
        $ownerSchema->addPropertyMapping('date_time', Order::names()->dateTime);

        // Use mapped name references after the default mapping was configured.
        $names = self::names($ownerSchema->properties);
        $ownerSchema->required = array(
            $names->id,         
            $names->dateTime, // "date_time"
            $names->price       
        );
```
