### PR TITLE
Permit installation when symfony/polyfill-mbstring is present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,5 @@
   },
   "suggest": {
     "ext-mbstring": "For better performance"
-  },
+  }
 }


### PR DESCRIPTION
I propose to require the `symfony/polyfill-mbstring` package, instead of the `mbstring` extension, to permit usage of this library on PHP server that does not have the extension loaded. For instance, it can happen on some shared hosting servers where users cannot choose which extension is installed.