### PR TITLE
Support typed properties

### DIFF
--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -104,6 +104,11 @@ trait ClassStructureTrait
         $processed = array();
         if (null !== $properties) {
             foreach ($properties->getDataKeyMap() as $propertyName => $dataName) {
+                if (!isset($this->$propertyName)) {
+                    // Skip uninitialized properties
+                    continue;
+                }
+                
                 $value = $this->$propertyName;
 
                 // Value is exported if exists.


### PR DESCRIPTION
PHP doesn't allow typed properties to be accessed if it is uninitialized:

```
PHP Fatal error:  Uncaught Error: Typed property Order::$user_id must not be accessed before initialization
```

This change skips properties if it is not set. I know this library doesn't really support PHP type declarations, but this is a pretty harmless change that does not affect existing functionality (: