### PR TITLE
Fix nullable fields

### DIFF
--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -104,10 +104,8 @@ trait ClassStructureTrait
         $processed = array();
         if (null !== $properties) {
             foreach ($properties->getDataKeyMap() as $propertyName => $dataName) {
-                if (!isset($this->$propertyName)) {
-                    // Skip uninitialized properties
-                    continue;
-                }
+                // Get uninitialized properties as null; direct access will throw error on typed properties
+                $value = isset($this->$propertyName) ? $this->$propertyName : null;
                 
                 $value = $this->$propertyName;
 


### PR DESCRIPTION
Change in https://github.com/swaggest/php-json-schema/pull/147 causes nullable JSON fields not to be exported.

This change should fix that.