### PR TITLE
Add return types to fix deprecation

### DIFF
--- a/src/MagicMapTrait.php
+++ b/src/MagicMapTrait.php
@@ -28,13 +28,13 @@ trait MagicMapTrait
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->__arrayOfData);
     }
 
     #[\ReturnTypeWillChange]
-    public function &offsetGet($offset)
+    public function &offsetGet($offset): mixed
     {
         if (isset($this->__arrayOfData[$offset])) {
             return $this->__arrayOfData[$offset];
@@ -45,13 +45,13 @@ trait MagicMapTrait
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->__set($offset, $value);
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->__arrayOfData[$offset]);
     }

--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -215,7 +215,7 @@ class Wrapper implements SchemaContract, MetaHolder, SchemaExporter, \JsonSerial
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->schema->jsonSerialize();
     }


### PR DESCRIPTION
One of our bundles is using `"swaggest/json-schema"` and we just came across some deprecation, just some simple fixes to update, hopefully it works (?):
![Screenshot from 2023-08-01 14-51-49](https://github.com/swaggest/php-json-schema/assets/38202941/4265abe8-6df0-4baa-82f4-005f9f518e13)
