### PR TITLE
Fix phpdoc for JsonSchena::setType()

### DIFF
--- a/src/JsonSchema.php
+++ b/src/JsonSchema.php
@@ -648,7 +648,7 @@ class JsonSchema extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param array $type
+     * @param array|string $type
      * @return $this
      * @codeCoverageIgnoreStart
      */


### PR DESCRIPTION
The type definition in `setType` method can be updated as the property itself accepts `string` too