### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ 'ubuntu-latest' ]
-        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ 'ubuntu-latest' ]
-        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ If you want to map data to a different class you can register mapping at top lev
 ```php
 class CustomSwaggerSchema extends SwaggerSchema
 {
-    public static function import($data, Context $options = null)
+    public static function import($data, ?Context $options = null)
     {
         if ($options === null) {
             $options = new Context();

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "High definition PHP structures with JSON-schema based validation",
   "type": "library",
   "require": {
-    "php": ">=5.4",
+    "php": ">=7.1",
     "ext-json": "*",
     "phplang/scope-exit": "^1.0",
     "swaggest/json-diff": "^3.8.2",
@@ -35,7 +35,7 @@
   },
   "config": {
     "platform": {
-      "php": "5.4.45"
+      "php": "7.1.33"
     }
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f85c752aa7be87c0a9ba169493adbeba",
+    "content-hash": "cc266b32b15203be9de99c8ffa8c5740",
     "packages": [
         {
             "name": "phplang/scope-exit",
@@ -1310,12 +1310,12 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.4.45"
+        "php": "7.1.33"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -75,7 +75,7 @@ class Context extends MagicMap
      * ProcessingOptions constructor.
      * @param RemoteRefProvider $remoteRefProvider
      */
-    public function __construct(RemoteRefProvider $remoteRefProvider = null)
+    public function __construct(?RemoteRefProvider $remoteRefProvider = null)
     {
         $this->remoteRefProvider = $remoteRefProvider;
     }

--- a/src/RemoteRef/Preloaded.php
+++ b/src/RemoteRef/Preloaded.php
@@ -42,7 +42,7 @@ class Preloaded implements RemoteRefProvider
      * @param Context|null $options
      * @throws \Swaggest\JsonSchema\Exception
      */
-    public function populateSchemas(RefResolver $refResolver, Context $options = null)
+    public function populateSchemas(RefResolver $refResolver, ?Context $options = null)
     {
         if ($options === null) {
             $options = new Context();

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -109,7 +109,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
      * @throws InvalidValue
      * @throws \Exception
      */
-    public static function import($data, Context $options = null)
+    public static function import($data, ?Context $options = null)
     {
         if (null === $options) {
             $options = new Context();
@@ -148,7 +148,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
      * @throws InvalidValue
      * @throws \Exception
      */
-    public function in($data, Context $options = null)
+    public function in($data, ?Context $options = null)
     {
         if (null !== $this->__booleanSchema) {
             if ($this->__booleanSchema) {
@@ -187,7 +187,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
      * @throws InvalidValue
      * @throws \Exception
      */
-    public function out($data, Context $options = null)
+    public function out($data, ?Context $options = null)
     {
         if ($options === null) {
             $options = new Context();
@@ -1385,7 +1385,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
      * @param Context $options
      * @return ObjectItemContract
      */
-    public function makeObjectItem(Context $options = null)
+    public function makeObjectItem(?Context $options = null)
     {
         if (null === $this->objectItemClass) {
             return new ObjectItem();

--- a/src/SchemaContract.php
+++ b/src/SchemaContract.php
@@ -22,7 +22,7 @@ interface SchemaContract
      * @throws InvalidValue
      * @return array|mixed|null|object|\stdClass
      */
-    public function in($data, Context $options = null);
+    public function in($data, ?Context $options = null);
 
     /**
      * @param mixed $data
@@ -30,7 +30,7 @@ interface SchemaContract
      * @throws InvalidValue
      * @return array|mixed|null|object|\stdClass
      */
-    public function out($data, Context $options = null);
+    public function out($data, ?Context $options = null);
 
     /**
      * @return mixed
@@ -44,7 +44,7 @@ interface SchemaContract
      * @param Context|null $options
      * @return Structure\ObjectItemContract
      */
-    public function makeObjectItem(Context $options = null);
+    public function makeObjectItem(?Context $options = null);
 
     /**
      * @return string

--- a/src/Structure/ClassStructureTrait.php
+++ b/src/Structure/ClassStructureTrait.php
@@ -55,7 +55,7 @@ trait ClassStructureTrait
      * @throws \Swaggest\JsonSchema\Exception
      * @throws \Swaggest\JsonSchema\InvalidValue
      */
-    public static function import($data, Context $options = null)
+    public static function import($data, ?Context $options = null)
     {
         return static::schema()->in($data, $options);
     }
@@ -67,7 +67,7 @@ trait ClassStructureTrait
      * @throws \Swaggest\JsonSchema\InvalidValue
      * @throws \Exception
      */
-    public static function export($data, Context $options = null)
+    public static function export($data, ?Context $options = null)
     {
         return static::schema()->out($data, $options);
     }
@@ -150,7 +150,7 @@ trait ClassStructureTrait
     /**
      * @return static|NameMirror
      */
-    public static function names(Properties $properties = null, $mapping = Schema::DEFAULT_MAPPING)
+    public static function names(?Properties $properties = null, $mapping = Schema::DEFAULT_MAPPING)
     {
         if ($properties !== null) {
             return new NameMirror($properties->getDataKeyMap($mapping));

--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -53,7 +53,7 @@ class Wrapper implements SchemaContract, MetaHolder, SchemaExporter, \JsonSerial
      * @throws Exception
      * @throws InvalidValue
      */
-    public function in($data, Context $options = null)
+    public function in($data, ?Context $options = null)
     {
         return $this->schema->in($data, $options);
     }
@@ -65,7 +65,7 @@ class Wrapper implements SchemaContract, MetaHolder, SchemaExporter, \JsonSerial
      * @throws InvalidValue
      * @throws \Exception
      */
-    public function out($data, Context $options = null)
+    public function out($data, ?Context $options = null)
     {
         return $this->schema->out($data, $options);
     }
@@ -199,7 +199,7 @@ class Wrapper implements SchemaContract, MetaHolder, SchemaExporter, \JsonSerial
      * @param Context|null $options
      * @return Structure\ObjectItemContract
      */
-    public function makeObjectItem(Context $options = null)
+    public function makeObjectItem(?Context $options = null)
     {
         return $this->schema->makeObjectItem($options);
     }


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated