### PR TITLE
Recursion Update for php-json-schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ User::export($user); // Exception: Required property missing: id at #->propertie
 
 #### Nested structures
 
-Nested structures allow you to make composition: flatten several objects in one and separate back.
+Nested structures allow you to make composition: flatten several objects in one and separate back.  For nested structures that exceed a depth of the default 200 recursion limit, submit a Context maxNestLevel of an appropriate amount.
 
 ```php
 $user = new User();
@@ -462,7 +462,8 @@ $this->assertSame(4, $res->one);
 #### Overriding mapping classes
 
 If you want to map data to a different class you can register mapping at top level of your importer structure.
-
+Additionally, you can use the option property, maxNestLevel to increase your depth beyond the default 200 which may be
+useful for certain complex Schema's.
 ```php
 class CustomSwaggerSchema extends SwaggerSchema
 {
@@ -470,6 +471,7 @@ class CustomSwaggerSchema extends SwaggerSchema
     {
         if ($options === null) {
             $options = new Context();
+            $options->maxNestLevel = 500;
         }
         $options->objectItemClassMapping[Schema::className()] = CustomSchema::className();
         return parent::import($data, $options);

--- a/src/Context.php
+++ b/src/Context.php
@@ -4,6 +4,8 @@ namespace Swaggest\JsonSchema;
 
 class Context extends MagicMap
 {
+    const DEFAULT_MAX_NEST = 200;
+    
     public $import = true;
 
     /** @var DataPreProcessor */
@@ -52,7 +54,7 @@ class Context extends MagicMap
     public $isRef = false;
 
     /** @var int property max recursive nesting depth */
-    public $maxNestLevel = 200;
+    public $maxNestLevel = DEFAULT_MAX_NEST;
 
     /**
      * Dereference $ref unless there is a $ref property defined with format not equal to `uri-reference`.

--- a/src/Context.php
+++ b/src/Context.php
@@ -51,6 +51,9 @@ class Context extends MagicMap
 
     public $isRef = false;
 
+    /** @var int property max recursive nesting depth */
+    public $maxNestLevel = 200;
+
     /**
      * Dereference $ref unless there is a $ref property defined with format not equal to `uri-reference`.
      * Default JSON Schema behavior is to dereference only if there is a $ref property defined with format

--- a/src/Context.php
+++ b/src/Context.php
@@ -54,7 +54,7 @@ class Context extends MagicMap
     public $isRef = false;
 
     /** @var int property max recursive nesting depth */
-    public $maxNestLevel = DEFAULT_MAX_NEST;
+    public $maxNestLevel = self::DEFAULT_MAX_NEST;
 
     /**
      * Dereference $ref unless there is a $ref property defined with format not equal to `uri-reference`.

--- a/src/RefResolver.php
+++ b/src/RefResolver.php
@@ -13,7 +13,7 @@ class RefResolver
     public $url;
     /** @var null|RefResolver */
     private $rootResolver;
-    private int $max_deep_nesting = 200; //Change this via options submitted to ::import if needed
+    private int $maxNestLevel = 200; //Change this via options submitted to ::import if needed
 
     /**
      * @param mixed $resolutionScope
@@ -103,10 +103,10 @@ class RefResolver
      * RefResolver constructor.
      * @param JsonSchema $rootData
      */
-    public function __construct($rootData = null, int $max_nest_level = 200)
+    public function __construct($rootData = null, int $maxNestLevel = 200)
     {
         $this->rootData = $rootData;
-        $this->max_deep_nesting = $max_nest_level;
+        $this->maxNestLevel = $max_nest_level;
     }
 
     public function setRootData($rootData)

--- a/src/RefResolver.php
+++ b/src/RefResolver.php
@@ -106,7 +106,7 @@ class RefResolver
     public function __construct($rootData = null, int $maxNestLevel = 200)
     {
         $this->rootData = $rootData;
-        $this->maxNestLevel = $max_nest_level;
+        $this->maxNestLevel = $maxNestLevel;
     }
 
     public function setRootData($rootData)

--- a/src/RefResolver.php
+++ b/src/RefResolver.php
@@ -226,8 +226,8 @@ class RefResolver
      */
     public function preProcessReferences($data, Context $options, $nestingLevel = 0)
     {
-        if ($nestingLevel > $this->max_deep_nesting) { //Updated due to specific recursion depth from Amazon product JSON Schemas - yep 200 was not enough
-            throw new Exception('Too deep nesting level. Suggest submitting maxNestLevel via options', Exception::DEEP_NESTING);
+        if ($nestingLevel > $this->maxNestLevel) { //Updated due to specific recursion depth from Amazon product JSON Schemas - yep 200 was not enough
+            throw new Exception('Too deep nesting level. Nesting / Recursion level (' . $nestingLevel . ') exceeds ' . $this->maxNestLevel , Exception::DEEP_NESTING);
         }
         if (is_array($data)) {
             foreach ($data as $key => $item) {

--- a/src/RefResolver.php
+++ b/src/RefResolver.php
@@ -13,6 +13,7 @@ class RefResolver
     public $url;
     /** @var null|RefResolver */
     private $rootResolver;
+    private static int $MAX_DEEP_NESTING = 500; //Change this if you receive DEEP_NESTING exceptions
 
     /**
      * @param mixed $resolutionScope
@@ -224,7 +225,7 @@ class RefResolver
      */
     public function preProcessReferences($data, Context $options, $nestingLevel = 0)
     {
-        if ($nestingLevel > 200) {
+        if ($nestingLevel > self::$MAX_DEEP_NESTING) { //Updated due to specific recursion depth from Amazon product JSON Schemas - yep 200 was not enough
             throw new Exception('Too deep nesting level', Exception::DEEP_NESTING);
         }
         if (is_array($data)) {

--- a/src/RefResolver.php
+++ b/src/RefResolver.php
@@ -13,7 +13,7 @@ class RefResolver
     public $url;
     /** @var null|RefResolver */
     private $rootResolver;
-    private static int $MAX_DEEP_NESTING = 500; //Change this if you receive DEEP_NESTING exceptions
+    private int $max_deep_nesting = 200; //Change this via options submitted to ::import if needed
 
     /**
      * @param mixed $resolutionScope
@@ -103,9 +103,10 @@ class RefResolver
      * RefResolver constructor.
      * @param JsonSchema $rootData
      */
-    public function __construct($rootData = null)
+    public function __construct($rootData = null, int $max_nest_level = 200)
     {
         $this->rootData = $rootData;
+        $this->max_deep_nesting = $max_nest_level;
     }
 
     public function setRootData($rootData)
@@ -225,8 +226,8 @@ class RefResolver
      */
     public function preProcessReferences($data, Context $options, $nestingLevel = 0)
     {
-        if ($nestingLevel > self::$MAX_DEEP_NESTING) { //Updated due to specific recursion depth from Amazon product JSON Schemas - yep 200 was not enough
-            throw new Exception('Too deep nesting level', Exception::DEEP_NESTING);
+        if ($nestingLevel > $this->max_deep_nesting) { //Updated due to specific recursion depth from Amazon product JSON Schemas - yep 200 was not enough
+            throw new Exception('Too deep nesting level. Suggest submitting maxNestLevel via options', Exception::DEEP_NESTING);
         }
         if (is_array($data)) {
             foreach ($data as $key => $item) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -165,7 +165,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
         $options->import = true;
 
         if ($options->refResolver === null) {
-            $options->refResolver = new RefResolver($data);
+            $options->refResolver = new RefResolver($data, $options->maxNestLevel ?? 200);
         } else {
             $options->refResolver->setRootData($data);
         }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -37,6 +37,8 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
     const CONST_PROPERTY = 'const';
     const DEFAULT_PROPERTY = 'default';
 
+    const DEFAULT_MAX_NEST = 200;
+
     const DEFAULT_MAPPING = 'default';
 
     const VERSION_AUTO = 'a';
@@ -165,7 +167,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
         $options->import = true;
 
         if ($options->refResolver === null) {
-            $options->refResolver = new RefResolver($data, $options->maxNestLevel ?? 200);
+            $options->refResolver = new RefResolver($data, $options->maxNestLevel ?? DEFAULT_MAX_NEST);
         } else {
             $options->refResolver->setRootData($data);
         }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -37,8 +37,6 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
     const CONST_PROPERTY = 'const';
     const DEFAULT_PROPERTY = 'default';
 
-    const DEFAULT_MAX_NEST = 200;
-
     const DEFAULT_MAPPING = 'default';
 
     const VERSION_AUTO = 'a';
@@ -167,7 +165,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract, HasDefaul
         $options->import = true;
 
         if ($options->refResolver === null) {
-            $options->refResolver = new RefResolver($data, $options->maxNestLevel ?? DEFAULT_MAX_NEST);
+            $options->refResolver = new RefResolver($data, $options->maxNestLevel ?? Context::DEFAULT_MAX_NEST);
         } else {
             $options->refResolver->setRootData($data);
         }


### PR DESCRIPTION
Amazon's Schema system necessitated an update to allow recursion in the RefResolver object beyond 200.  This code updates the system to allow an option to be submitted via option->maxNestLevel if recursion greater than 200 is needed. (or less).

Example:
`$options = new \Swaggest\JsonSchema\Context();

$options->maxNestLevel = 500;

$schema = Schema::import($data, $options);`

My first attempt to provide a fix / better feature - be gentle.